### PR TITLE
use google's vrf package rather than psvrf

### DIFF
--- a/vrf/README.md
+++ b/vrf/README.md
@@ -1,3 +1,6 @@
 ## Introduction 
 
-This package contains some wrapper code of [VRF library](https://gitlab.com/abhvious/vrf) which is an implementation of the Verifiable Random Function from the Pass-Shelat Micropayments paper.
+This package contains wrapper codes of discrete log based verifiable random function from Appendix A of [CONIKS](http://www.jbonneau.com/doc/MBBFF15-coniks.pdf) which is implemented in [github.com/google/keytransparency/core/crypto/vrf/p256](https://github.com/google/keytransparency/tree/master/core/crypto/vrf/p256) package. 
+
+
+

--- a/vrf/vrf_test.go
+++ b/vrf/vrf_test.go
@@ -44,3 +44,16 @@ func TestVrf(t *testing.T) {
 		t.Fatal("failed")
 	}
 }
+
+func BenchmarkVrf(b *testing.B) {
+	pri, _, err := keypair.GenerateKeyPair(keypair.PK_ECDSA, keypair.P256)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		msg := []byte("test")
+		Vrf(pri, msg)
+	}
+}


### PR DESCRIPTION
Google's vrf package gives a more secure implementation than psvrf. In google's implementation,

- the first hash function(called  `hashToCurve` in psvrf) use SHA512(m || i)[0 : 64] as the x coordinate,

- the second hash function use simple discard method, rather than use SHA256(m) mod N directly.