### PR TITLE
optimize the DecodePublicKey function

### DIFF
--- a/ec/decompress.go
+++ b/ec/decompress.go
@@ -1,0 +1,243 @@
+/*
+ * Copyright (C) 2018 The ontology Authors
+ * This file is part of The ontology library.
+ *
+ * The ontology is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The ontology is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with The ontology.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ec
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"errors"
+	"math/big"
+)
+
+func getLowestSetBit(k *big.Int) int {
+	i := 0
+	for i = 0; k.Bit(i) != 1; i++ {
+	}
+	return i
+}
+
+func isEven(k *big.Int) bool {
+	if k.Bit(0) == 0 {
+		return true
+	} else {
+		return false
+	}
+}
+
+// fastLucasSequence refer to https://en.wikipedia.org/wiki/Lucas_sequence
+func fastLucasSequence(curveP, lucasParamP, lucasParamQ, k *big.Int) (*big.Int, *big.Int) {
+	n := k.BitLen()
+	s := getLowestSetBit(k)
+
+	uh := big.NewInt(1)
+	vl := big.NewInt(2)
+	ql := big.NewInt(1)
+	qh := big.NewInt(1)
+	vh := big.NewInt(0).Set(lucasParamP)
+	tmp := big.NewInt(0)
+
+	for j := n - 1; j >= s+1; j-- {
+		ql.Mul(ql, qh)
+		ql.Mod(ql, curveP)
+
+		if k.Bit(j) == 1 {
+			qh.Mul(ql, lucasParamQ)
+			qh.Mod(qh, curveP)
+
+			uh.Mul(uh, vh)
+			uh.Mod(uh, curveP)
+
+			vl.Mul(vh, vl)
+			tmp.Mul(lucasParamP, ql)
+			vl.Sub(vl, tmp)
+			vl.Mod(vl, curveP)
+
+			vh.Mul(vh, vh)
+			tmp.Lsh(qh, 1)
+			vh.Sub(vh, tmp)
+			vh.Mod(vh, curveP)
+		} else {
+			qh.Set(ql)
+
+			uh.Mul(uh, vl)
+			uh.Sub(uh, ql)
+			uh.Mod(uh, curveP)
+
+			vh.Mul(vh, vl)
+			tmp.Mul(lucasParamP, ql)
+			vh.Sub(vh, tmp)
+			vh.Mod(vh, curveP)
+
+			vl.Mul(vl, vl)
+			tmp.Lsh(ql, 1)
+			vl.Sub(vl, tmp)
+			vl.Mod(vl, curveP)
+		}
+	}
+
+	ql.Mul(ql, qh)
+	ql.Mod(ql, curveP)
+
+	qh.Mul(ql, lucasParamQ)
+	qh.Mod(qh, curveP)
+
+	uh.Mul(uh, vl)
+	uh.Sub(uh, ql)
+	uh.Mod(uh, curveP)
+
+	vl.Mul(vh, vl)
+	tmp.Mul(lucasParamP, ql)
+	vl.Sub(vl, tmp)
+	vl.Mod(vl, curveP)
+
+	ql.Mul(ql, qh)
+	ql.Mod(ql, curveP)
+
+	for j := 1; j <= s; j++ {
+		uh.Mul(uh, vl)
+		uh.Mul(uh, curveP)
+
+		vl.Mul(vl, vl)
+		tmp.Lsh(ql, 1)
+		vl.Sub(vl, tmp)
+		vl.Mod(vl, curveP)
+
+		ql.Mul(ql, ql)
+		ql.Mod(ql, curveP)
+	}
+
+	return uh, vl
+}
+
+// compute the coordinate of Y from Y**2
+func curveSqrt(ySquare *big.Int, curve *elliptic.CurveParams) *big.Int {
+	if curve.P.Bit(1) == 1 {
+		tmp1 := big.NewInt(0)
+		tmp1.Rsh(curve.P, 2)
+		tmp1.Add(tmp1, big.NewInt(1))
+
+		tmp2 := big.NewInt(0)
+		tmp2.Exp(ySquare, tmp1, curve.P)
+
+		tmp3 := big.NewInt(0)
+		tmp3.Exp(tmp2, big.NewInt(2), curve.P)
+
+		if 0 == tmp3.Cmp(ySquare) {
+			return tmp2
+		}
+		return nil
+	}
+
+	qMinusOne := big.NewInt(0)
+	qMinusOne.Sub(curve.P, big.NewInt(1))
+
+	legendExponent := big.NewInt(0)
+	legendExponent.Rsh(qMinusOne, 1)
+
+	tmp4 := big.NewInt(0)
+	tmp4.Exp(ySquare, legendExponent, curve.P)
+	if 0 != tmp4.Cmp(big.NewInt(1)) {
+		return nil
+	}
+
+	k := big.NewInt(0)
+	k.Rsh(qMinusOne, 2)
+	k.Lsh(k, 1)
+	k.Add(k, big.NewInt(1))
+
+	lucasParamQ := big.NewInt(0)
+	lucasParamQ.Set(ySquare)
+	fourQ := big.NewInt(0)
+	fourQ.Lsh(lucasParamQ, 2)
+	fourQ.Mod(fourQ, curve.P)
+
+	seqU := big.NewInt(0)
+	seqV := big.NewInt(0)
+
+	for {
+		lucasParamP := big.NewInt(0)
+		for {
+			tmp5 := big.NewInt(0)
+			lucasParamP, _ = rand.Prime(rand.Reader, curve.P.BitLen())
+
+			if lucasParamP.Cmp(curve.P) < 0 {
+				tmp5.Mul(lucasParamP, lucasParamP)
+				tmp5.Sub(tmp5, fourQ)
+				tmp5.Exp(tmp5, legendExponent, curve.P)
+
+				if 0 == tmp5.Cmp(qMinusOne) {
+					break
+				}
+			}
+		}
+
+		seqU, seqV = fastLucasSequence(curve.P, lucasParamP, lucasParamQ, k)
+
+		tmp6 := big.NewInt(0)
+		tmp6.Mul(seqV, seqV)
+		tmp6.Mod(tmp6, curve.P)
+		if 0 == tmp6.Cmp(fourQ) {
+			if 1 == seqV.Bit(0) {
+				seqV.Add(seqV, curve.P)
+			}
+			seqV.Rsh(seqV, 1)
+			return seqV
+		}
+		if (0 == seqU.Cmp(big.NewInt(1))) || (0 == seqU.Cmp(qMinusOne)) {
+			break
+		}
+	}
+	return nil
+}
+
+// deCompress is for computing the coordinate of Y based the coordinate of X
+func deCompress(yTilde int, xValue []byte, curve *elliptic.CurveParams) (*ecdsa.PublicKey, error) {
+	xCoord := big.NewInt(0)
+	xCoord.SetBytes(xValue)
+
+	//y**2 = x**3 + A*x +B, A = -3, there is no A's clear definition in the realization of p256.
+	paramA := big.NewInt(-3)
+	//compute x**3 + A*x +B
+	ySqare := big.NewInt(0)
+	ySqare.Exp(xCoord, big.NewInt(2), curve.P)
+	ySqare.Add(ySqare, paramA)
+	ySqare.Mod(ySqare, curve.P)
+	ySqare.Mul(ySqare, xCoord)
+	ySqare.Mod(ySqare, curve.P)
+	ySqare.Add(ySqare, curve.B)
+	ySqare.Mod(ySqare, curve.P)
+
+	yValue := curveSqrt(ySqare, curve)
+	if nil == yValue {
+		return nil, errors.New("Invalid point compression")
+	}
+
+	yCoord := big.NewInt(0)
+	if (isEven(yValue) && 0 != yTilde) || (!isEven(yValue) && 1 != yTilde) {
+		yCoord.Sub(curve.P, yValue)
+	} else {
+		yCoord.Set(yValue)
+	}
+	return &ecdsa.PublicKey{
+		X:     xCoord,
+		Y:     yCoord,
+		Curve: curve,
+	}, nil
+}

--- a/ec/key.go
+++ b/ec/key.go
@@ -123,24 +123,7 @@ func DecodePublicKey(data []byte, curve elliptic.Curve) (*ecdsa.PublicKey, error
 		//	return nil, errors.New("Point is not on the curve")
 		//}
 	} else if data[0] == compress_even || data[0] == compress_odd {
-		bi3 := big.NewInt(3)
-		y = new(big.Int).Exp(x, bi3, curve.Params().P)
-		a := new(big.Int).Sub(curve.Params().P, bi3)
-		ax := new(big.Int).Mul(x, a)
-		ax = ax.Mod(ax, curve.Params().P)
-		y = y.Add(y, ax)
-		y = y.Mod(y, curve.Params().P)
-		y = y.Add(y, curve.Params().B)
-		y = y.Mod(y, curve.Params().P)
-		y = new(big.Int).ModSqrt(y, curve.Params().P)
-
-		if y == nil {
-			return nil, errors.New("Invalid X value")
-		}
-
-		if y.Bit(0) != uint(data[0])&1 {
-			y = y.Sub(curve.Params().P, y)
-		}
+		return deCompress(int(data[0]&1), data[1:length+1], curve.Params())
 	} else {
 		return nil, errors.New("unknown encoding mode")
 	}

--- a/keypair/key_test.go
+++ b/keypair/key_test.go
@@ -165,3 +165,19 @@ func TestComparePublicKey(t *testing.T) {
 		t.Fatal("public keys not equal")
 	}
 }
+
+func BenchmarkDeserilize(b *testing.B) {
+	var opts byte
+	opts = P256
+	_, pub, _ := GenerateKeyPair(PK_ECDSA, opts)
+
+	serPub := SerializePublicKey(pub)
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, err := DeserializePublicKey(serPub)
+		if err != nil {
+			b.Fatal("bug")
+		}
+	}
+}


### PR DESCRIPTION
This PR can achieves about 50% speed-up than the straightforward `ModSqrt` function by using fast curveSqrt function.