### PR TITLE
Add pbc(bn256) version for vrf

### DIFF
--- a/bn256/key.go
+++ b/bn256/key.go
@@ -1,0 +1,53 @@
+package bn256
+
+import (
+	"crypto"
+	"io"
+	"math/big"
+
+	originBN256 "golang.org/x/crypto/bn256"
+)
+
+// PublicKey is the type of Ed25519 public keys.
+type PublicKey struct {
+	v *originBN256.G1
+}
+
+// Value returns the value of this.
+func (this PublicKey) Value() *originBN256.G1 {
+	v := *(this.v)
+	return &v
+}
+
+// PrivateKey is the type of Ed25519 private keys. It implements crypto.Signer.
+type PrivateKey struct {
+	v *big.Int
+}
+
+// Public returns the PublicKey corresponding to priv.
+func (this PrivateKey) Public() crypto.PublicKey {
+	pub := new(originBN256.G1).ScalarBaseMult(this.v)
+	publicKey := new(PublicKey)
+	publicKey.v = pub
+	return publicKey
+}
+
+// Value returns the value of this.
+func (this PrivateKey) Value() *big.Int {
+	v := new(big.Int)
+	v.Set(this.v)
+	return v
+}
+
+// GenerateKey generates a new key pair of BN256 Pairing Curve
+func GenerateKey(rand io.Reader) (PublicKey, PrivateKey, error) {
+	pri, pub, err := originBN256.RandomG1(rand)
+
+	privateKey := new(PrivateKey)
+	privateKey.v = pri
+
+	publicKey := new(PublicKey)
+	publicKey.v = pub
+
+	return *publicKey, *privateKey, err
+}

--- a/keypair/ecurves.go
+++ b/keypair/ecurves.go
@@ -38,6 +38,8 @@ const (
 
 	// ED25519 curve label
 	ED25519 byte = 25
+
+	BN256 byte = 64
 )
 
 func GetCurveLabel(c elliptic.Curve) (byte, error) {

--- a/keypair/key.go
+++ b/keypair/key.go
@@ -38,6 +38,7 @@ import (
 	"reflect"
 
 	base58 "github.com/itchyny/base58-go"
+	"github.com/ontio/ontology-crypto/bn256"
 	"github.com/ontio/ontology-crypto/ec"
 
 	"golang.org/x/crypto/ed25519"
@@ -57,6 +58,7 @@ const (
 	PK_ECDSA KeyType = 0x12
 	PK_SM2   KeyType = 0x13
 	PK_EDDSA KeyType = 0x14
+	PK_BN256 KeyType = 0x15
 
 	PK_P256_E KeyType = 0x02
 	PK_P256_O KeyType = 0x03
@@ -99,6 +101,9 @@ func GenerateKeyPair(t KeyType, opts interface{}) (PrivateKey, PublicKey, error)
 		} else {
 			return nil, nil, errors.New(err_generate + "unsupported EdDSA scheme")
 		}
+	case PK_BN256:
+		pub, pri, err := bn256.GenerateKey(rand.Reader)
+		return pri, pub, err
 	default:
 		return nil, nil, errors.New(err_generate + "unknown algorithm")
 	}

--- a/vrf/vrf_pbc.go
+++ b/vrf/vrf_pbc.go
@@ -24,3 +24,182 @@ package vrf
  *  include a NIZK proof for it suffices to verify the equation
  *      e(vrf, g) = e(Hg(m), pk)
  */
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"fmt"
+	"math/big"
+	"reflect"
+
+	"golang.org/x/crypto/bn256"
+)
+
+// KeyPairBN256 contains private key and public key
+type KeyPairBN256 struct {
+	pri *big.Int
+	pub *bn256.G1
+}
+
+// GenKeyPair generates a new key pair of BN256 Pairing Curve
+func GenKeyPair() (kp *KeyPairBN256, err error) {
+
+	// pri, err := rand.Int(rand.Reader, bn256.Order)
+
+	// pub := new(bn256.G1)
+	// pub.ScalarBaseMult(pri)
+
+	kp = new(KeyPairBN256)
+
+	pri, pub, err := bn256.RandomG1(rand.Reader)
+
+	kp.pri = pri
+	kp.pub = pub
+
+	return
+}
+
+// GetPri return private key
+func (this *KeyPairBN256) GetPri() *big.Int {
+	return this.pri
+}
+
+// GetPub return public key
+func (this *KeyPairBN256) GetPub() *bn256.G1 {
+	return this.pub
+}
+
+func (this *KeyPairBN256) SelfCheck() error {
+
+	if this.pri == nil {
+		return *new(error)
+	}
+
+	if this.pub == nil {
+		return *new(error)
+	}
+
+	pub := new(bn256.G1)
+	pub.ScalarBaseMult(this.pri)
+
+	if this.pub.String() != pub.String() {
+		return *new(error)
+	}
+
+	return nil
+}
+
+/* funcs */
+
+// VrfPbc returns the verifiable random function evaluated m and a NIZK proof
+// Proof()
+func VrfPbc(kp *KeyPairBN256, msg []byte) ([]byte, []byte) {
+
+	// check key pair
+	if kp.SelfCheck() != nil {
+		fmt.Printf("key pairis in wrong format. \n")
+	}
+
+	// check message
+	if msg == nil {
+		fmt.Printf("message is empty. \n")
+	}
+
+	// compute
+
+	// g1
+	g1 := new(bn256.G1).ScalarBaseMult(big.NewInt(1))
+
+	// g2
+	g2 := new(bn256.G2).ScalarBaseMult(big.NewInt(1))
+
+	// hash message
+	digest := sha256.Sum256(msg)
+	x := big.NewInt(0).SetBytes(digest[:])
+	// _x := big.NewInt(0).SetBytes(digest[:])
+
+	// F(sk, x)
+	egg := bn256.Pair(g1, g2) // egg = e(g1, g2)
+
+	// fmt.Printf("#### x: %v \n", x)
+
+	tmp := x.Add(x, kp.pri)
+	tmp = tmp.ModInverse(tmp, bn256.Order) // 1/... mod n
+	f := egg.ScalarMult(egg, tmp)
+
+	// fmt.Printf("#### tmp: %v \n", tmp)
+	// fmt.Printf("#### f: %v \n", f.Marshal())
+
+	// _egg := bn256.Pair(g1.ScalarMult(g1, tmp), g2) // egg = e(g1, g2)
+
+	// fmt.Printf("#### _x: %v \n", _x)
+	// fmt.Printf("#### _egg: %v \n", _egg.Marshal())
+	// fmt.Printf("#### _egg: %v \n", _egg.Marshal())
+
+	// pi(sk, x)
+
+	pi := new(bn256.G2)
+	pi = pi.ScalarBaseMult(tmp)
+
+	// marshal
+
+	m_f := f.Marshal()
+	m_pi := pi.Marshal()
+
+	// return
+	return m_f, m_pi
+}
+
+func VrfPbcVerify(pk *bn256.G1, msg []byte, m_f []byte, m_pi []byte) (bool, error) {
+	f, ok := new(bn256.GT).Unmarshal(m_f)
+
+	if !ok {
+		fmt.Printf("### m_f ### \n")
+		return false, nil
+	}
+
+	pi, ok := new(bn256.G2).Unmarshal(m_pi)
+
+	if !ok {
+		fmt.Printf("### m_pi ### \n")
+		return false, nil
+	}
+
+	// hash message
+	digest := sha256.Sum256(msg)
+	x := big.NewInt(0).SetBytes(digest[:])
+
+	// g1
+	g1 := new(bn256.G1).ScalarBaseMult(big.NewInt(1))
+
+	// g2
+	g2 := new(bn256.G2).ScalarBaseMult(big.NewInt(1))
+
+	egg := bn256.Pair(g1, g2) // egg = e(g1, g2)
+
+	g1.ScalarBaseMult(x)
+	g1.Add(g1, pk)
+
+	first := bn256.Pair(g1, pi)
+	fmt.Printf("first: %v \n", first)
+	fmt.Printf("egg: %v \n", egg)
+	if !reflect.DeepEqual(first.Marshal(), egg.Marshal()) {
+		fmt.Printf("### first ### \n")
+		return false, nil
+	}
+
+	g1.ScalarBaseMult(big.NewInt(1))
+	second := bn256.Pair(g1, pi)
+	if !reflect.DeepEqual(second.Marshal(), f.Marshal()) {
+		fmt.Printf("### second ### \n")
+		return false, nil
+	}
+
+	return true, nil
+
+}
+
+// //Vrf returns the verifiable random function evaluated m and a NIZK proof
+// func Vrf(pri *big.Int, pub *bn256.G1, msg []byte) (vrf, nizk []byte, err error) {
+
+// }

--- a/vrf/vrf_pbc.go
+++ b/vrf/vrf_pbc.go
@@ -60,6 +60,11 @@ func (this *KeyPairBN256) GetPri() *big.Int {
 	return this.pri
 }
 
+// SetPri sets the private key
+func (this *KeyPairBN256) SetPri(newV *big.Int) *big.Int {
+	return this.pri.Set(newV)
+}
+
 // GetPub return public key
 func (this *KeyPairBN256) GetPub() *bn256.G1 {
 	return this.pub


### PR DESCRIPTION
# use bn256 from "golang.org/x/crypto/bn256"
# add wrapper for bn256 to adapt to current ontology/crypto
# add test case and benchmark to vrfpbc