### PR TITLE
Fixed: According to the GB/T 32918.2-2016 (Page 3, 6.1), when r=0 or …

### DIFF
--- a/sm2/signature.go
+++ b/sm2/signature.go
@@ -171,10 +171,7 @@ func Sign(rand io.Reader, priv *ecdsa.PrivateKey, id string, msg []byte, hasher 
 			r, _ = priv.ScalarBaseMult(k.Bytes())
 			r.Add(r, e)
 			r.Mod(r, N)
-			if r.Sign() != 0 {
-				break
-			}
-			if t := new(big.Int).Add(r, k); t.Cmp(N) == 0 {
+			if r.Sign() != 0 && new(big.Int).Add(r, k).Cmp(N) != 0 {
 				break
 			}
 		}


### PR DESCRIPTION
Fixed: According to the GB/T 32918.2-2016 (Page 3, 6.1), when r=0 or r+k=n, it should return to Step A3.
@AlverLyu